### PR TITLE
Firebase Emulator Setup and Documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,12 @@
 # Service Mode Configuration
 # Set to 'firebase' to use Firebase services, 'local' to use localStorage
-VITE_SERVICE_MODE=local
+VITE_SERVICE_MODE=firebase
 
 # Firebase Configuration (only needed when VITE_SERVICE_MODE=firebase)
-VITE_FIREBASE_API_KEY=your_api_key_here
-VITE_FIREBASE_AUTH_DOMAIN=your_project.firebaseapp.com
-VITE_FIREBASE_PROJECT_ID=your_project_id
-VITE_FIREBASE_STORAGE_BUCKET=your_project.appspot.com
-VITE_FIREBASE_MESSAGING_SENDER_ID=your_sender_id
-VITE_FIREBASE_APP_ID=your_app_id
-VITE_FIREBASE_MEASUREMENT_ID=your_measurement_id
+VITE_FIREBASE_API_KEY=demo
+VITE_FIREBASE_AUTH_DOMAIN=demo-borg.firebaseapp.com
+VITE_FIREBASE_PROJECT_ID=demo-borg
+VITE_FIREBASE_STORAGE_BUCKET=demo-borg.appspot.com
+VITE_FIREBASE_MESSAGING_SENDER_ID=demo-borg
+VITE_FIREBASE_APP_ID=demo-borg
+VITE_FIREBASE_MEASUREMENT_ID=demo-borg

--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 
 # Claude
-CLAUDE.md
+CLAUDE.local.md
 CLAUDE
 docs
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,85 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+### Development
+- `pnpm dev` - Start development server (uses pnpm, not npm)
+- `pnpm build` - Build production version
+- `pnpm preview` - Preview production build
+
+### Code Quality
+- `pnpm lint` - Run prettier check and eslint
+- `pnpm format` - Format code with prettier
+- `pnpm check` - Run Svelte type checking
+- `pnpm check:watch` - Run Svelte type checking in watch mode
+
+### Firebase Emulator (for testing)
+- `docker-compose up` - Start Firebase emulators via Docker
+- Access Firebase UI at http://localhost:4000
+- Emulator ports: Auth (9099), Firestore (8080), Storage (9199)
+
+## Architecture Overview
+
+### Service Architecture Pattern
+The codebase uses a **dual-service architecture** that switches between local storage and Firebase based on the `VITE_SERVICE_MODE` environment variable:
+
+- **Local Mode**: Data stored in browser localStorage (default)
+- **Firebase Mode**: Data stored in Firebase with authentication required
+
+The `ServiceFactory` class (`src/lib/services/ServiceFactory.ts`) creates appropriate service instances:
+- Projects, Tasks, People, Timeline, Nodes, and User services
+- Sticker service always uses Firebase Storage regardless of mode
+- Mode switching controlled by `VITE_SERVICE_MODE=firebase` environment variable
+
+### Key Service Interfaces
+All services implement interfaces in `src/lib/services/interfaces/`:
+- `IProjectsService` - Project management
+- `ITaskService` - Task management with hierarchical support
+- `IPeopleService` - People/contact management
+- `ITimelineService` - Timeline events
+- `INodesService` - Canvas node management (uses @xyflow/svelte)
+- `IStickerService` - Sticker/image management
+- `IUserService` - User profile management
+
+### Firebase Configuration
+- Firebase config in `src/lib/firebase/config.ts`
+- Auto-connects to emulators when project ID starts with 'demo-'
+- Emulator setup via Docker with `firebase.emulator.docker.json`
+
+### Authentication
+- Firebase Auth integration via `authStore` (Svelte store)
+- User approval system with member/collaborator roles
+- Authentication wrapper in `+layout.svelte` only active in Firebase mode
+
+### Frontend Stack
+- **SvelteKit 5** with TypeScript
+- **TailwindCSS 4** for styling
+- **@xyflow/svelte** for canvas/flow diagrams
+- **Lucide Svelte** for icons
+
+### Component Structure
+- `src/lib/components/` - Reusable components
+- `src/lib/components/UniversalNode/` - Canvas node types (Note, Sticker, Image, Iframe)
+- `src/lib/components/browser/` - Tab-based browser interface components
+- `src/lib/components/fields/` - Dynamic form field system
+- `src/lib/components/tasks/` - Task management UI
+
+### Key Patterns
+- Services instantiated via factory pattern for mode switching
+- Interface-based design for service abstractions
+- Svelte stores for state management (`authStore`)
+- Dynamic field rendering system for extensible forms
+- Canvas-based project visualization with node system
+
+### Environment Variables
+- `VITE_SERVICE_MODE` - 'local' or 'firebase' (defaults to local)
+- Firebase config variables (API keys, project ID, etc.)
+- Use `demo-` prefix in project ID to enable emulator mode
+
+### Development Notes
+- Uses pnpm package manager
+- Legacy local services marked as deprecated (see `src/lib/services/local/README.md`)
+- Firebase emulator setup supports full development workflow
+- Authentication required only in Firebase mode

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ docker-compose up -d
 pnpm dev
 ```
 
+When using Firebase emulators, the fake Google Sign-In dialog will let you create fake accounts and sign in with any email address. Use an email starting with "admin" (e.g., `admin@example.com`) to automatically get admin permissions.
+
 ### Building
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,38 +1,75 @@
-# sv
+# Borg
 
-Everything you need to build a Svelte project, powered by [`sv`](https://github.com/sveltejs/cli).
+A visual project management and knowledge organization platform built with SvelteKit. Borg combines canvas-based project visualization with traditional task management, creating a collaborative workspace where teams can organize projects, tasks, timelines, and knowledge in an interconnected visual interface.
 
-## Creating a project
+## Features
 
-If you're seeing this, you've probably already done this step. Congrats!
+### 🎨 Visual Canvas Interface
 
-```sh
-# create a new project in the current directory
-npx sv create
+- **Project Canvas**: Individual project workspaces with rich node-based content
+- **Project Portfolio**: Overview canvas showing all projects with summary information
+- **Universal Nodes**: Support for notes (Post-It style), images, iframes, and stickers
+- **Drag & Drop**: Intuitive visual organization with @xyflow/svelte
 
-# create a new project in my-app
-npx sv create my-app
+### 📋 Task Management
+
+- **Node-Centric Tasks**: Tasks attached to specific canvas elements
+- **Person Assignment**: Assign tasks to team members with profile integration
+- **Due Dates**: Track deadlines with overdue detection
+- **Status Tracking**: Active/resolved task states with reactivation capability
+- **Hierarchical Views**: Organize tasks by Project → Node → Task structure
+
+### 👥 Collaboration
+
+- **People Management**: Team member profiles and contact information
+- **Project Collaboration**: Multi-user access with member/collaborator roles
+- **Real-time Updates**: Live synchronization when using Firebase backend
+- **Timeline Events**: Track project milestones and important dates
+
+## Getting Started
+
+### Prerequisites
+
+- Node.js 22
+- pnpm
+
+### Installation
+
+```bash
+# Install dependencies
+pnpm install
+
+# Set up environment
+cp .env.example .env
 ```
 
-## Developing
+### Development
 
-Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
+```bash
+# Run Firebase emulators
+docker-compose up -d
 
-```sh
-npm run dev
-
-# or start the server and open the app in a new browser tab
-npm run dev -- --open
+# Start app
+pnpm dev
 ```
 
-## Building
+### Building
 
-To create a production version of your app:
+```bash
+# Create production build
+pnpm build
 
-```sh
-npm run build
+# Preview production build
+pnpm preview
 ```
 
-You can preview the production build with `npm run preview`.
+## Code Quality
 
-> To deploy your app, you may need to install an [adapter](https://svelte.dev/docs/kit/adapters) for your target environment.
+```bash
+# Type checking
+pnpm check
+
+# Linting and formatting
+pnpm lint
+pnpm format
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  firebase:
+    image: ghcr.io/dtinth/firebase-emulator-suite:main
+    volumes:
+      - ./firebase.emulator.docker.json:/project/firebase.json:ro
+      - ./firestore.rules:/project/firestore.rules:ro
+      - ./firestore.indexes.json:/project/firestore.indexes.json:ro
+    ports:
+      - 9099:9099
+      - 8080:8080
+      - 9000:9000
+      - 8085:8085
+      - 9199:9199
+      - 4000:4000
+      - 4500:4500
+      - 9150:9150

--- a/firebase.emulator.docker.json
+++ b/firebase.emulator.docker.json
@@ -1,0 +1,37 @@
+{
+	"firestore": {
+		"rules": "firestore.rules",
+		"indexes": "firestore.indexes.json"
+	},
+	"storage": {
+		"rules": "storage.rules"
+	},
+	"emulators": {
+		"auth": {
+			"host": "0.0.0.0",
+			"port": 9099
+		},
+		"firestore": {
+			"host": "0.0.0.0",
+			"port": 8080
+		},
+		"database": {
+			"host": "0.0.0.0",
+			"port": 9000
+		},
+		"pubsub": {
+			"host": "0.0.0.0",
+			"port": 8085
+		},
+		"storage": {
+			"host": "0.0.0.0",
+			"port": 9199
+		},
+		"ui": {
+			"host": "0.0.0.0",
+			"enabled": true,
+			"port": 4000
+		},
+		"singleProjectMode": true
+	}
+}

--- a/package.json
+++ b/package.json
@@ -47,5 +47,6 @@
 		"@xyflow/svelte": "^1.2.2",
 		"firebase": "^12.0.0",
 		"node-fetch": "^2.7.0"
-	}
+	},
+	"packageManager": "pnpm@10.15.1+sha512.34e538c329b5553014ca8e8f4535997f96180a1d0f614339357449935350d924e22f8614682191264ec33d1462ac21561aff97f6bb18065351c162c7e8f6de67"
 }

--- a/src/lib/firebase/config.ts
+++ b/src/lib/firebase/config.ts
@@ -1,6 +1,7 @@
 import { initializeApp } from 'firebase/app';
-import { getFirestore, connectFirestoreEmulator } from 'firebase/firestore';
-import { getAuth, connectAuthEmulator } from 'firebase/auth';
+import { connectAuthEmulator, getAuth } from 'firebase/auth';
+import { connectFirestoreEmulator, getFirestore } from 'firebase/firestore';
+import { connectStorageEmulator, getStorage } from 'firebase/storage';
 
 // Your web app's Firebase configuration
 const firebaseConfig = {
@@ -16,13 +17,18 @@ const firebaseConfig = {
 export const app = initializeApp(firebaseConfig);
 export const db = getFirestore(app);
 export const auth = getAuth(app);
+export const storage = getStorage(app);
 
-// Connect to emulators in development
-// if (import.meta.env.DEV) {
-// 	try {
-// 		connectFirestoreEmulator(db, 'localhost', 8080);
-// 		connectAuthEmulator(auth, 'http://localhost:9099');
-// 	} catch {
-// 		// Emulators already connected
-// 	}
-// }
+export let isEmulator = false;
+
+// Connect to emulators if project ID starts with 'demo-'
+if (firebaseConfig.projectId.startsWith('demo-')) {
+	isEmulator = true;
+	try {
+		connectFirestoreEmulator(db, 'localhost', 8080);
+		connectAuthEmulator(auth, 'http://localhost:9099');
+		connectStorageEmulator(storage, 'localhost', 9199);
+	} catch {
+		// Emulators already connected
+	}
+}


### PR DESCRIPTION
## Summary
- Set up Firebase emulator development environment with Docker
- Add comprehensive project documentation and developer guides
- Configure demo mode for easy local development

<img width="923" height="752" alt="tldrawFile" src="https://github.com/user-attachments/assets/09e592e9-25a3-436b-8a6c-c6bed466cef9" />

## Context
@chayapatr mentioned that local mode is considered legacy, so I set up Firebase emulator support for modern development workflow. Also found the project was lacking a proper README, so generated comprehensive documentation.

## Changes Made

### 🚀 Firebase Emulator Setup
- **Docker Compose**: Added `docker-compose.yml` with Firebase emulator suite
- **Emulator Config**: Created `firebase.emulator.docker.json` with proper host bindings
- **Auto-connect Logic**: Enhanced `config.ts` to automatically connect to emulators when using `demo-` project ID
- **Demo Mode**: Updated `.env.example` to use demo Firebase config by default

### 📚 Documentation
- **README.md**: Complete rewrite with proper project description, setup instructions, and development workflow
- **CLAUDE.md**: Added AI assistant guidance for future development work
- **Auth Guide**: Documented Firebase emulator authentication (use `admin@example.com` for admin access)

### 🔧 Development Experience
- **Environment Setup**: Streamlined from `cp .env.example .env` → `docker-compose up -d` → `pnpm dev`
- **Admin Access**: Automatic admin permissions for emails starting with "admin" in emulator mode
- **Package Manager**: Locked to pnpm@10.15.1 for consistency

## Test Plan
- [x] Firebase emulators start correctly with `docker-compose up -d`
- [x] App connects to emulators automatically with demo config
- [x] Authentication works with fake Google accounts
- [x] Admin permissions granted for admin-prefixed emails
- [x] All existing functionality preserved
- [x] Documentation is clear and actionable

🤖 Generated with [Claude Code](https://claude.ai/code)